### PR TITLE
Configure RabbitMQ URL with setters instead of environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,21 +24,25 @@ Or install it yourself as:
 ## Usage
 
 The gem is meant to be used by a sender application and one or more receiver
-applications. The RabbitMQ instance used is configured via the RABBIT_URL environment variable.
+applications.
 
 ### On the sender side
 
-`Caerbannog::Queue` needs to be configured with a message storage class that is an
+Caerbannog needs to be configured with a message storage class that is an
 ActiveRecord model or works like an ActiveRecord model with regards to the
 methods `.all`, `.create!` and `#destroy`, and has two attributes `name` and
-`payload`.
+`payload`. It also needs a RabbitMQ read and a write URL.
 
 ```ruby
-Caerbannog::Queue.message_class = MessageQueueMessage
+Caerbannog.configure do |config|
+  config.message_class = MessageQueueMessage
+  config.rabbit_read_url = ENV['RABBIT_URL']
+  config.rabbit_write_url = ENV['RABBIT_URL']
+end
 ```
 
 If you are using the gem from within a Rails application, you can run the
-following to generate this model:
+following to generate this model and the configuration:
 
     $ rails generate caerbannog
 

--- a/lib/caerbannog.rb
+++ b/lib/caerbannog.rb
@@ -5,3 +5,15 @@ require 'json'
 require 'caerbannog/version'
 require 'caerbannog/message_poller'
 require 'caerbannog/queue'
+
+module Caerbannog
+  class ConfigurationError < StandardError; end
+
+  class << self
+    attr_accessor :message_class, :rabbit_read_url, :rabbit_write_url
+
+    def configure
+      yield self
+    end
+  end
+end

--- a/lib/caerbannog/version.rb
+++ b/lib/caerbannog/version.rb
@@ -1,3 +1,3 @@
 module Caerbannog
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/lib/generators/templates/caerbannog_initializer.rb
+++ b/lib/generators/templates/caerbannog_initializer.rb
@@ -1,1 +1,5 @@
-Caerbannog::Queue.message_class = CaerbannogMessage
+Caerbannog::Queue.configure do |config|
+  config.message_class = CaerbannogMessage
+  config.rabbit_read_url = ENV['RABBIT_URL']
+  config.rabbit_write_url = ENV['RABBIT_URL']
+end

--- a/spec/queue_spec.rb
+++ b/spec/queue_spec.rb
@@ -2,22 +2,31 @@ require 'spec_helper'
 
 describe Caerbannog::Queue do
   describe '.push' do
+    it 'must be configured with a message_class' do
+      expect { Caerbannog::Queue.push('rabbit', {}) }.to raise_error(Caerbannog::ConfigurationError)
+    end
+
     it 'creates a Message' do
       message_class = stub
       message_class.expects(:create!).with(:name => 'name', :payload => '{"a":"1"}')
-      Caerbannog::Queue.message_class = message_class
+      Caerbannog.configure { |config| config.message_class = message_class }
       Caerbannog::Queue.push('name', { 'a' => '1' })
     end
   end
 
   describe '.rabbitmq' do
+    it 'must be configured with read and write URLs' do
+      expect { Caerbannog::Queue.rabbitmq(nil) {} }.to raise_error(Caerbannog::ConfigurationError)
+    end
+
     it 'yields the exchange and the channel' do
-      exchange, channel = stub_bunny
+      rabbit_url = 'http://example.com/rabbits'
+      exchange, channel = stub_bunny(rabbit_url)
       checker = mock('checker')
 
       checker.expects(:has_yielded).with(exchange, channel)
 
-      Caerbannog::Queue.rabbitmq do |ex, ch|
+      Caerbannog::Queue.rabbitmq rabbit_url do |ex, ch|
         checker.has_yielded(ex, ch)
       end
     end
@@ -25,7 +34,8 @@ describe Caerbannog::Queue do
 
   describe '.subscribe' do
     it 'subscribes to a queue' do
-      exchange, channel = stub_bunny
+      rabbit_read_url = 'http://example.com/rx'
+      exchange, channel = stub_bunny(rabbit_read_url)
       queue = mock('queue')
       checker = mock('checker')
       yielded_params1 = [stub, stub, 'payload1']
@@ -39,13 +49,15 @@ describe Caerbannog::Queue do
       checker.expects(:has_yielded).with(*yielded_params1)
       checker.expects(:has_yielded).with(*yielded_params2)
 
+      Caerbannog.configure { |config| config.rabbit_read_url = rabbit_read_url }
       Caerbannog::Queue.subscribe('queue_name', 'issue_published', 'issue_unpublished', &block)
     end
   end
 
   describe '.publish' do
     it 'publishes a stream of messages to the exchange' do
-      exchange, _ = stub_bunny
+      rabbit_write_url = 'http://example.com/tx'
+      exchange, _ = stub_bunny(rabbit_write_url)
       expected_name = 'something'
       expected_payload = '{"a":"1"}'
       message = mock('message', :name => expected_name, :payload => expected_payload)
@@ -54,18 +66,19 @@ describe Caerbannog::Queue do
       exchange.expects(:publish).with(expected_payload, :routing_key => expected_name, :persistent => true)
       message.expects(:destroy)
 
+      Caerbannog.configure { |config| config.rabbit_write_url = rabbit_write_url }
       Caerbannog::Queue.publish(messages)
     end
   end
 end
 
-def stub_bunny
+def stub_bunny(redis_url)
   exchange = mock('exchange')
   channel = mock('channel')
   conn = mock('conn')
   conn.expects(:create_channel).returns(channel)
   channel.expects(:direct).returns(exchange)
-  Bunny.expects(:run).yields(conn)
+  Bunny.expects(:run).with(redis_url).yields(conn)
 
   return exchange, channel
 end


### PR DESCRIPTION
Make RabbitMQ URLs configurable

Also move configuration to the module.

Caerbannog.message_class
Caerbannog.rabbit_read_url
Caerbannog.rabbit_write_url
